### PR TITLE
Make drivers license field not required

### DIFF
--- a/webapp/accounts/forms.py
+++ b/webapp/accounts/forms.py
@@ -55,7 +55,10 @@ class VokoUserFinishForm(forms.ModelForm):
         widget=forms.Textarea
     )
 
-    has_drivers_license = forms.BooleanField(label='Ik heb een rijbewijs')
+    has_drivers_license = forms.BooleanField(
+        label='Ik heb een rijbewijs',
+        required=False
+    )
 
     accept_terms_and_privacy = forms.BooleanField(
         label="Ik heb het Reglement en het Privacy Statement van "
@@ -161,7 +164,10 @@ class ChangeProfileForm(forms.ModelForm):
         required=False
     )
 
-    has_drivers_license = forms.BooleanField(label='Ik heb een rijbewijs')
+    has_drivers_license = forms.BooleanField(
+        label='Ik heb een rijbewijs',
+        required=False
+    )
 
     password1 = forms.CharField(
         label="Wachtwoord (alleen invullen als je deze wilt wijzigen)",


### PR DESCRIPTION
I noticed that the has drivers license field was required, leading to:
![screenshot from 2019-02-19 22-20-13](https://user-images.githubusercontent.com/523210/53048911-26128f00-3496-11e9-9eba-0d1c41b2a5d4.png)

Probably not what we want. I hope this PR fixes that.