### PR TITLE
Sort accounts

### DIFF
--- a/webapp/accounts/admin.py
+++ b/webapp/accounts/admin.py
@@ -161,7 +161,6 @@ class VokoUserBaseAdmin(UserAdmin):
     list_filter = ("is_staff", "is_superuser", "is_active",
                    "can_activate", "groups")
     search_fields = ("email", 'first_name', 'last_name')
-    # ordering = ("-created", )
     ordering = ("first_name", "last_name")
     filter_horizontal = ("groups", "user_permissions",)
     fieldsets = (

--- a/webapp/accounts/admin.py
+++ b/webapp/accounts/admin.py
@@ -161,7 +161,8 @@ class VokoUserBaseAdmin(UserAdmin):
     list_filter = ("is_staff", "is_superuser", "is_active",
                    "can_activate", "groups")
     search_fields = ("email", 'first_name', 'last_name')
-    ordering = ("-created", )
+    # ordering = ("-created", )
+    ordering = ("first_name", "last_name")
     filter_horizontal = ("groups", "user_permissions",)
     fieldsets = (
         (None, {"fields": ("email", "password", "first_name",


### PR DESCRIPTION
For some reason this seems like the easiest way to sort the accounts in the Ride admin. 

I also tried adding `ordering = ["first_name", "last_name"]` to the `Meta` of `VokoUser` but that didn't seem to have an effect. 

I could have also added something like below to the `RideAdmin` but that's costs way more code:
```
    def formfield_for_foreignkey(self, db_field, request, **kwargs):
        if db_field.name == "driver":
            kwargs["queryset"] = VokoUser.objects.order_by(
                'first_name',
                'last_name'
            )
        return super(RideAdmin, self).formfield_for_foreignkey(
            db_field,
            request,
            **kwargs
        )
```


Possible downside of this PR is that this also alters the sorting on `/admin/accounts/vokouser/` but I think that's okay?

Related to: #21 