### PR TITLE
Customize order round name in Ride admin form

### DIFF
--- a/webapp/transport/admin.py
+++ b/webapp/transport/admin.py
@@ -12,6 +12,14 @@ class RideAdmin(admin.ModelAdmin):
     list_display = ["date", "route", "driver", "codriver"]
     ordering = ("-id", )
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(RideAdmin, self).get_form(request, obj, **kwargs)
+        order_round_field = form.base_fields['order_round']
+        order_round_field.label_from_instance = format_order_round
+        return form
+
+def format_order_round (obj):
+    return "%s %s" % (obj, obj.collect_datetime.strftime("%Y-%m-%d"))
 
 admin.site.register(Route, RouteAdmin)
 admin.site.register(Ride, RideAdmin)

--- a/webapp/transport/admin.py
+++ b/webapp/transport/admin.py
@@ -18,8 +18,10 @@ class RideAdmin(admin.ModelAdmin):
         order_round_field.label_from_instance = format_order_round
         return form
 
-def format_order_round (obj):
+
+def format_order_round(obj):
     return "%s %s" % (obj, obj.collect_datetime.strftime("%Y-%m-%d"))
+
 
 admin.site.register(Route, RouteAdmin)
 admin.site.register(Ride, RideAdmin)


### PR DESCRIPTION
The OrderRound in the Ride admin was only displayed using a number, which probably has no significance to the Ride creator. This PR includes the collect date in the dropdown. 

See: #21