### PR TITLE
Clarify no orders

### DIFF
--- a/webapp/templates/transport/ride.html
+++ b/webapp/templates/transport/ride.html
@@ -85,42 +85,44 @@
       </thead>
       <tbody>
         {% for supplier, items in object.orders_per_supplier.items %}
-          {% if items.orderproducts %}
-            <tr class="success">
-                <td>{{ supplier.name }}</td>
-                <td>{{ supplier.address }}</td>
-                <td>
-                  {{ supplier.contact_person }}<br />
-                  {{ supplier.email }}<br />
-                  {{ supplier.phone_number }}
-                </td>
-                <td>{{ supplier.transport_info }}</td>
-            </tr>
-            <tr>
-              <td colspan="4">
-                  <table class="table">
-                    <thead>
+          <tr class="{{ items.orderproducts|yesno:"success,warning" }}">
+            <td>{{ supplier.name }}</td>
+            <td>{{ supplier.address }}</td>
+            <td>
+              {{ supplier.contact_person }}<br />
+              {{ supplier.email }}<br />
+              {{ supplier.phone_number }}
+            </td>
+            <td>{{ supplier.transport_info }}</td>
+          </tr>
+          <tr>
+            <td colspan="4">
+              {% if items.orderproducts %}
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th>Aantal</th>
+                      <th>Eenheid</th>
+                      <th>Product</th>
+                      <th>Omschrijving</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for item in items.orderproducts %}
                       <tr>
-                        <th>Aantal</th>
-                        <th>Eenheid</th>
-                        <th>Product</th>
-                        <th>Omschrijving</th>
+                        <td>{{ item.amount }}</td>
+                        <td>{{ item.product.unit_of_measurement }}</td>
+                        <td>{{ item.product.name }}</td>
+                        <td>{{ item.product.description }}</td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {% for item in items.orderproducts %}
-                          <tr>
-                            <td>{{ item.amount }}</td>
-                            <td>{{ item.product.unit_of_measurement }}</td>
-                            <td>{{ item.product.name }}</td>
-                            <td>{{ item.product.description }}</td>
-                          </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
-                </td>
-            </tr>
-          {% endif %}
+                    {% endfor %}
+                  </tbody>
+                </table>
+              {% else %}
+                Geen bestellingen
+              {% endif %}
+            </td>
+          </tr>
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
In the template I would filter out suppliers without orders. I think that was probably a bad idea. This could cause confusion when the ride page would be viewed before it's OrderRound would be closed, because there would be no suppliers listed. 
There is also something to say that it's informative to declare that there where no orders for certain suppliers. 