### PR TITLE
Improved short role names

### DIFF
--- a/webapp/accounts/admin.py
+++ b/webapp/accounts/admin.py
@@ -122,8 +122,13 @@ class UserProfileInline(admin.StackedInline):
 
 def roles(self):
     # https://djangosnippets.org/snippets/1650/
+    def short_name_part(name):
+        return name[:2].upper()
+
     def short_name(name):
-        return str(name)[:3].upper()
+        name_parts = str(name).split(" ")
+        short_name_parts = map(short_name_part, name_parts)
+        return "_".join(short_name_parts)
 
     p = sorted(["<a title='%s'>%s</a>" % (
         x, short_name(x)) for x in self.groups.all()]


### PR DESCRIPTION
Fixes: #66

Converts "Transport" into "TR" and "Transport coordinator" into "TR_CO". 

![Screenshot from 2019-06-23 01-00-00@2x](https://user-images.githubusercontent.com/523210/59969637-b0f1bc00-9552-11e9-9f3e-ee4109093cb4.png)
