### PR TITLE
Per order round account info page

### DIFF
--- a/webapp/ordering/admin_urls.py
+++ b/webapp/ordering/admin_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from .admin_views import OrderAdminMain, OrderAdminOrderLists, \
     OrderAdminUserOrdersPerProduct, OrderAdminUserOrders, \
     OrderAdminSupplierOrderCSV, OrderAdminUserOrderProductsPerOrderRound, \
-    OrderAdminCorrection, OrderAdminMassCorrection, \
+    OrderAdminCorrection, OrderAccounts, OrderAdminMassCorrection, \
     OrderAdminCorrectionJson, UploadProductList, CreateDraftProducts, \
     CreateRealProducts, ProductAdminMain, \
     RedirectToMailingView, StockAdminView, ProductStockApiView, ProductApiView
@@ -33,6 +33,8 @@ urlpatterns = (
         OrderAdminMassCorrection.as_view(), name="orderadmin_mass_correction"),
     url(r'^round/(?P<pk>[0-9]+)/correction/$', OrderAdminCorrection.as_view(),
         name="orderadmin_correction"),
+    url(r'^round/(?P<pk>[0-9]+)/accounts/$', OrderAccounts.as_view(),
+        name="orderadmin_accounts"),
     url(r'^round/(?P<pk>[0-9]+)/mailing/(?P<mailing_type>(round-open))/$',
         RedirectToMailingView.as_view(), name="productadmin_mailing"),
     url(r'^product/(?P<pk>[0-9]+)/$', OrderAdminUserOrdersPerProduct.as_view(),

--- a/webapp/ordering/admin_views.py
+++ b/webapp/ordering/admin_views.py
@@ -211,6 +211,12 @@ class OrderAdminCorrection(GroupRequiredMixin, TemplateView):
         return OrderRound.objects.get(pk=self.kwargs.get('pk'))
 
 
+class OrderAccounts(GroupRequiredMixin, DetailView):
+    model = OrderRound
+    template_name = "ordering/admin/orderround_accounts.html"
+    group_required = ('Admin')
+
+
 class OrderAdminMassCorrection(GroupRequiredMixin, View):
     group_required = ('Uitdeelcoordinatoren', 'Admin')
 

--- a/webapp/templates/ordering/admin/orderround_accounts.html
+++ b/webapp/templates/ordering/admin/orderround_accounts.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Leden info bestelronde #{{ object.pk }}</h1>
+
+{% if object.is_open %}
+    <div class="alert alert-danger" role="alert"><strong>Let op!</strong> Deze bestelronde is nog open. Er kunnen nog nieuwe bestellingen worden gedaan!</div>
+{% endif %}
+
+<h2>Leden die voor het eerst besteld hebben</h2>
+<div class="panel panel-default">
+  {% for order in object.orders.all %}
+    <ul class="list-group">
+      {% if order.member_fee %}
+        <a href="{% url 'admin:accounts_vokouser_change' order.user.id %}"><li class="list-group-item">{{ order.user }}</li></a>
+      {% endif %}
+    </ul>
+  {% endfor %}
+</div>
+
+{% endblock %}
+
+
+
+

--- a/webapp/templates/ordering/admin/orderrounds.html
+++ b/webapp/templates/ordering/admin/orderrounds.html
@@ -16,6 +16,9 @@
         <th>Unieke bestellingen</th>
         <th>Overzicht bestellingen per product</th>
         <th>Correcties</th>
+        {% if 'Admin' in user.flat_groups or user.is_superuser %}
+          <th>Leden</th>
+        {% endif %}
       </tr>
     </thead>
     <tbody>
@@ -29,6 +32,9 @@
             <td><a href="{% url 'orderadmin_userorders' orderround.pk %}">{{ orderround.number_of_orders }}</a></td>
             <td><a href="{% url 'orderadmin_orders_per_product' orderround.pk %}">Per product</a></td>
             <td><a href="{% url 'orderadmin_correction' orderround.pk %}">Correcties</a></td>
+            {% if 'Admin' in user.flat_groups or user.is_superuser %}
+              <td><a href="{% url 'orderadmin_accounts' orderround.pk %}">Leden</a></td>
+            {% endif %}
           </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Part of #63

A page with account admin relevant info per order round:
![Screenshot from 2019-07-14 22-49-30@2x](https://user-images.githubusercontent.com/523210/61189182-4b44ab80-a68a-11e9-8cd1-7defdd734e3c.png)
![Screenshot from 2019-07-14 22-49-09@2x](https://user-images.githubusercontent.com/523210/61189184-4f70c900-a68a-11e9-93d0-3d28eb65e214.png)
