### PR TITLE
Limit transport access

### DIFF
--- a/webapp/ordering/admin_views.py
+++ b/webapp/ordering/admin_views.py
@@ -28,7 +28,7 @@ from .models import OrderProduct, Order, OrderRound, Supplier, \
 
 class OrderAdminMain(GroupRequiredMixin, ListView):
     template_name = "ordering/admin/orderrounds.html"
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin')
+    group_required = ('Uitdeelcoordinatoren', 'Admin')
 
     def get_queryset(self):
         return OrderRound.objects.all().order_by('-id')
@@ -37,12 +37,12 @@ class OrderAdminMain(GroupRequiredMixin, ListView):
 class OrderAdminOrderLists(GroupRequiredMixin, DetailView):
     model = OrderRound
     template_name = "ordering/admin/orderround.html"
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin')
+    group_required = ('Uitdeelcoordinatoren', 'Admin')
 
 
 class OrderAdminSupplierOrderCSV(GroupRequiredMixin, ListView):
     template_name = "ordering/admin/orderlist_per_supplier.html"
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin', 'Boeren')
+    group_required = ('Uitdeelcoordinatoren', 'Admin', 'Boeren')
 
     def get_queryset(self):
         supplier = Supplier.objects.get(pk=self.kwargs.get('supplier_pk'))
@@ -58,7 +58,7 @@ class OrderAdminSupplierOrderCSV(GroupRequiredMixin, ListView):
 
 
 class OrderAdminUserOrdersPerProduct(GroupRequiredMixin, ListView):
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin', 'Boeren')
+    group_required = ('Uitdeelcoordinatoren', 'Admin', 'Boeren')
     template_name = "ordering/admin/productorder.html"
 
     def get_queryset(self):
@@ -68,7 +68,7 @@ class OrderAdminUserOrdersPerProduct(GroupRequiredMixin, ListView):
 
 
 class OrderAdminUserOrders(GroupRequiredMixin, ListView):
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin', 'Boeren')
+    group_required = ('Uitdeelcoordinatoren', 'Admin', 'Boeren')
     template_name = "ordering/admin/user_orders_per_round.html"
 
     def get_queryset(self):
@@ -84,7 +84,7 @@ class OrderAdminUserOrders(GroupRequiredMixin, ListView):
 
 # Bestellingen per product
 class OrderAdminUserOrderProductsPerOrderRound(GroupRequiredMixin, ListView):
-    group_required = ('Uitdeelcoordinatoren', 'Transport', 'Admin', 'Boeren')
+    group_required = ('Uitdeelcoordinatoren', 'Admin', 'Boeren')
     template_name = "ordering/admin/productsorders.html"
 
     def get_queryset(self):

--- a/webapp/templates/header.html
+++ b/webapp/templates/header.html
@@ -15,7 +15,7 @@
     </li>
 {% endif %}
 
-{% if 'Transport' in user.flat_groups or 'Uitdeelcoordinatoren' in user.flat_groups or 'Boeren' in user.flat_groups or 'Admin' in user.flat_groups or user.is_superuser %}
+{% if 'Uitdeelcoordinatoren' in user.flat_groups or 'Boeren' in user.flat_groups or 'Admin' in user.flat_groups or user.is_superuser %}
     <li><a href="{% url 'orderadmin_main' %}">Besteloverzichten</a></li>
 {% endif %}
 


### PR DESCRIPTION
Nu we het nieuwe transport rooster hebben waar de transporteurs alle info via dit systeem krijgen hebben ze geen toegang meer nodig tot de bestel informatie waar veel meer privacy gevoelige informatie in staat.

Fixes: #67