### PR TITLE
Moving panel heading to table header

### DIFF
--- a/webapp/templates/ordering/admin/productsorders.html
+++ b/webapp/templates/ordering/admin/productsorders.html
@@ -26,32 +26,41 @@
 
                 {% for product, orderproducts in products.items %}
                     <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h2><b>{{ product.name }} ({{ product.supplier.name }}) {% if product.is_stock_product %} <span class="label label-danger">uit voorraad</span> {% endif %} {% if not product.is_stock_product %}
-                                <small>totaal: {{ product.amount_ordered }} x {{ product.unit_of_measurement }}</small>
-                            {% endif %}</b></h2>
-                        </div>
-                        <div class="panel-body">{{ product.description }}</div>
-                            <table class="table table-condensed">
-                                <thead>
+                        <table class="table table-condensed">
+                            <thead>
+                                <tr>
+                                    <th colspan="4">
+                                        <div class="panel-heading">
+                                            <h2><b>{{ product.name }} ({{ product.supplier.name }})
+                                                {% if product.is_stock_product %}
+                                                    <span class="label label-danger">uit voorraad</span>
+                                                {% endif %}
+                                                {% if not product.is_stock_product %}
+                                                    <small>totaal: {{ product.amount_ordered }} x {{ product.unit_of_measurement }}</small>
+                                                {% endif %}
+                                            </b></h2>
+                                        </div>
+                                        <div class="panel-body">{{ product.description }}</div>
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <th>Aantal</th>
+                                    <th>Eenheid</th>
+                                    <th>Lid</th>
+                                    <th>Bestelling ID</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for op in orderproducts|dictsort:"order.user.first_name" %}
                                     <tr>
-                                        <th>Aantal</th>
-                                        <th>Eenheid</th>
-                                        <th>Lid</th>
-                                        <th>Bestelling ID</th>
+                                        <td>{{ op.amount }}</td>
+                                        <td>{{ op.product.unit_of_measurement }}</td>
+                                        <td>{{ op.order.user.get_full_name }}</td>
+                                        <td>#{{ op.order.pk }}</td>
                                     </tr>
-                                </thead>
-                                <tbody>
-                                    {% for op in orderproducts|dictsort:"order.user.first_name" %}
-                                        <tr>
-                                            <td>{{ op.amount }}</td>
-                                            <td>{{ op.product.unit_of_measurement }}</td>
-                                            <td>{{ op.order.user.get_full_name }}</td>
-                                            <td>#{{ op.order.pk }}</td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                 {% endfor %}
             {% endif %}

--- a/webapp/templates/ordering/admin/user_orders_per_round.html
+++ b/webapp/templates/ordering/admin/user_orders_per_round.html
@@ -15,19 +15,21 @@
 
     {% for order in object_list %}
     <div class="panel panel-default">
-        <div class="panel-heading">
-            <h1>{{ forloop.counter }}/{{ object_list|length }}: {{ order.user.get_full_name }}</h1>
-        </div>
-
-        <div class="panel-body">
-            Bestelling-ID: {{ order.pk }}
-            | ronde {{ order.order_round.id }}
-            | e-mail: {{ order.user.email }}
-            | telefoon: {{ order.user.userprofile.phone_number|default:"onbekend" }}
-        </div>
-
         <table class="table table-condensed">
             <thead>
+                <tr>
+                    <th colspan="6">
+                        <div class="panel-heading">
+                            <h1>{{ forloop.counter }}/{{ object_list|length }}: {{ order.user.get_full_name }}</h1>
+                        </div>
+                        <div class="panel-body">
+                            Bestelling-ID: {{ order.pk }}
+                            | ronde {{ order.order_round.id }}
+                            | e-mail: {{ order.user.email }}
+                            | telefoon: {{ order.user.userprofile.phone_number|default:"onbekend" }}
+                        </div>
+                    </th>
+                </tr>
                 <tr>
                     <th>Aantal</th>
                     <th>Eenheid</th>


### PR DESCRIPTION
Door de panel-header info in de table header te zetten, wordt deze informatie herhaald als de table niet op de pagina past.

Voor product orders werkt dit goed, maar voor user_orders niet. Als de header te groot is wordt de header niet herhaald op de volgende pagina. Ik heb hier nog geen oplossing voor, behalve de header in kleiner font af te drukken. Is dat werkbaar? 

NB Onder Firefox werkt het meer consistent dan onder Chrome.