### PR TITLE
header part of table + not show urls when printing

### DIFF
--- a/webapp/assets/css/theme.css
+++ b/webapp/assets/css/theme.css
@@ -68,3 +68,9 @@ body {
 .product .order .row {
   margin-bottom: 15px;
 }
+
+@media print {
+  a[href]::after {
+    content: none !important;
+  }
+}

--- a/webapp/templates/ordering/admin/orderround.html
+++ b/webapp/templates/ordering/admin/orderround.html
@@ -7,10 +7,15 @@
 {% endif %}
 
 {% for supplier, items in object.orders_per_supplier.items %}
-<h2><a href="{% url 'orderadmin_supplier_order_csv' object.pk supplier.pk %}">{{ supplier }}</a></h2>
+
 <div class="panel panel-default">
   <table class="table">
     <thead>
+      <tr>
+        <th colspan="6">
+        <h2><a href="{% url 'orderadmin_supplier_order_csv' object.pk supplier.pk %}">{{ supplier }}</a></h2>
+      </th>
+      </tr>
       <tr>
         <th>Aantal</th>
         <th>Eenheid</th>


### PR DESCRIPTION
Added the same fix for "Bestellijsten voor leveranciers". Also hidden the in page URLs when printing the page